### PR TITLE
use serde instead of rustc_serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ license = "MIT/Apache-2.0"
 [dependencies]
 bitflags = "0.4.0"
 arrayref = "0.3.2"
-rustc-serialize = "0.3.19"
+serde = "1.0"
+serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 bitflags = "1.0"
-arrayref = "0.3.2"
+arrayref = "0.3.5"
 serde = "1.0"
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Generic interface to manipulate various CD image formats"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-bitflags = "0.4.0"
+bitflags = "1.0"
 arrayref = "0.3.2"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/bcd.rs
+++ b/src/bcd.rs
@@ -9,7 +9,7 @@ use std::fmt;
 /// A single packed BCD value in the range 0-99 (2 digits, 4bits per
 /// digit).
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord,
-         RustcDecodable, RustcEncodable)]
+         Serialize, Deserialize)]
 pub struct Bcd(u8);
 
 impl Bcd {

--- a/src/bigarray.rs
+++ b/src/bigarray.rs
@@ -1,0 +1,69 @@
+//! Workaround for big arrays (len > 32), see https://github.com/serde-rs/serde/issues/631
+
+use std::fmt;
+use std::marker::PhantomData;
+use serde::ser::{Serialize, Serializer, SerializeTuple};
+use serde::de::{Deserialize, Deserializer, Visitor, SeqAccess, Error};
+
+pub trait BigArray<'de>: Sized {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer;
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>;
+}
+
+macro_rules! big_array {
+    ($($len:expr,)+) => {
+        $(
+            impl<'de, T> BigArray<'de> for [T; $len]
+                where T: Default + Copy + Serialize + Deserialize<'de>
+            {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where S: Serializer
+                {
+                    let mut seq = serializer.serialize_tuple(self.len())?;
+                    for elem in &self[..] {
+                        seq.serialize_element(elem)?;
+                    }
+                    seq.end()
+                }
+
+                fn deserialize<D>(deserializer: D) -> Result<[T; $len], D::Error>
+                    where D: Deserializer<'de>
+                {
+                    struct ArrayVisitor<T> {
+                        element: PhantomData<T>,
+                    }
+
+                    impl<'de, T> Visitor<'de> for ArrayVisitor<T>
+                        where T: Default + Copy + Deserialize<'de>
+                    {
+                        type Value = [T; $len];
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str(concat!("an array of length ", $len))
+                        }
+
+                        fn visit_seq<A>(self, mut seq: A) -> Result<[T; $len], A::Error>
+                            where A: SeqAccess<'de>
+                        {
+                            let mut arr = [T::default(); $len];
+                            for i in 0..$len {
+                                arr[i] = seq.next_element()?
+                                    .ok_or_else(|| Error::invalid_length(i, &self))?;
+                            }
+                            Ok(arr)
+                        }
+                    }
+
+                    let visitor = ArrayVisitor { element: PhantomData };
+                    deserializer.deserialize_tuple($len, visitor)
+                }
+            }
+        )+
+    }
+}
+
+big_array! {
+    2352,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ extern crate bitflags;
 #[macro_use]
 extern crate arrayref;
 
-extern crate rustc_serialize;
+extern crate serde;
+#[macro_use] extern crate serde_derive;
 
 use std::path::PathBuf;
 use std::io;
@@ -25,6 +26,7 @@ pub mod internal;
 pub mod sector;
 pub mod cue;
 pub mod crc;
+mod bigarray;
 
 /// Abstract read-only interface to an image format
 pub trait Image {
@@ -43,7 +45,7 @@ pub trait Image {
 }
 
 /// Possible session formats.
-#[derive(PartialEq, Eq, Clone, Copy, Debug, RustcDecodable, RustcEncodable)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum SessionFormat {
     /// CD-DA (audio CD, "red book" specification) or CD-ROM ("yellow
     /// book" specification) session
@@ -57,7 +59,7 @@ pub enum SessionFormat {
 }
 
 /// Possible track types
-#[derive(PartialEq, Eq, Clone, Copy, Debug, RustcDecodable, RustcEncodable)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum TrackFormat {
     /// CD-DA audio track (red book audio)
     Audio,

--- a/src/msf.rs
+++ b/src/msf.rs
@@ -13,7 +13,7 @@ use super::bcd::Bcd;
 /// CD "minute:second:frame" timestamp, given as triplet of *BCD*
 /// encoded bytes. In this context "frame" is synonymous with
 /// "sector".
-#[derive(Clone, Copy, PartialEq, Eq, RustcDecodable, RustcEncodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Msf(Bcd, Bcd, Bcd);
 
 impl Msf {

--- a/src/sector.rs
+++ b/src/sector.rs
@@ -1,16 +1,15 @@
 //! CD sector interface.
 
-use rustc_serialize::{Decodable, Encodable, Decoder, Encoder};
-
 use CdError;
 use TrackFormat;
 
 use msf::Msf;
 use bcd::Bcd;
+use bigarray::BigArray;
 
 /// Sector metadata, contains informations about the position and
 /// format of a given sector.
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Serialize, Deserialize)]
 pub struct Metadata {
     /// Absolute MSF of the sector
     pub msf: Msf,
@@ -30,15 +29,18 @@ pub struct Metadata {
 /// Structure containing a single sector. For better peformance it
 /// tries to be as lazy as possible and regenerate missing sector data
 /// only if it's requested.
+#[derive(Serialize, Deserialize)]
 pub struct Sector {
     /// Which portions of `data` are currently valid
     ready: DataReady,
     /// Actual sector data, only the portions set in `ready` are
     /// currently valid.
+    #[serde(with = "BigArray")]
     data: [u8; 2352],
     /// Sector metadata
     metadata: Metadata,
 }
+
 
 impl Sector {
     /// Create a new empty sector
@@ -112,73 +114,10 @@ impl Sector {
     }
 }
 
-impl Encodable for Sector {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-
-        s.emit_struct("Sector", 3, |s| {
-            try!(s.emit_struct_field("ready", 0,
-                                     |s| self.ready.encode(s)));
-
-            try!(s.emit_struct_field(
-                "data", 1,
-                |s| s.emit_seq(
-                    2352,
-                    |s| {
-                        for (i, &b) in self.data.iter().enumerate() {
-                            try!(s.emit_seq_elt(i, |s| b.encode(s)))
-                        }
-
-                        Ok(())
-                    })));
-
-            try!(s.emit_struct_field("metadata", 2,
-                                     |s| self.metadata.encode(s)));
-
-
-            Ok(())
-        })
-    }
-}
-
-impl Decodable for Sector {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Sector, D::Error> {
-        d.read_struct("Sector", 3, |d| {
-            let mut sector = Sector::empty();
-
-            sector.ready =
-                try!(d.read_struct_field("ready", 0,
-                                         Decodable::decode));
-
-            try!(d.read_struct_field(
-                    "data", 1,
-                    |d| {
-                        d.read_seq(|d, len| {
-                            if len != 2352 {
-                                return Err(
-                                    d.error("wrong sector data length"));
-                            }
-
-                            for i in 0..len {
-                                sector.data[i] =
-                                    try!(d.read_seq_elt(i, Decodable::decode));
-                            }
-
-                            Ok(len)
-                        })
-                    }));
-
-            sector.metadata =
-                try!(d.read_struct_field("metadata", 2,
-                                         Decodable::decode));
-
-            Ok(sector)
-        })
-    }
-}
 
 bitflags! {
     /// Bitflag holding the data ready to be read from the sector.
-    #[derive(RustcDecodable, RustcEncodable)]
+    #[derive(Serialize, Deserialize)]
     flags DataReady: u8 {
         /// 16byte sector header for CD-ROM and CDi data
         /// tracks. Contains the sync pattern, MSF and mode of the


### PR DESCRIPTION
I wanted to tackle https://github.com/simias/rustation/issues/38, and I thought I'd try on a smaller projet first, so here is a conversion from rustc_serialize to serde.

The only trouble is the following, I had to use a macro to serialize the data field.
I could validate a full serialize/deserialize cycle, because the ROMs I tried panicked with: `Unhandled CUE pregap read`

Let me know what you think about this PR